### PR TITLE
Load YAML safely

### DIFF
--- a/ipyaml/cli.py
+++ b/ipyaml/cli.py
@@ -13,7 +13,7 @@ def read_nb(fname):
 
 
 def read_yaml(fname):
-    data = yaml.load(open(fname))
+    data = yaml.safe_load(open(fname))
     return yaml_to_nb(data)
 
 


### PR DESCRIPTION
The default `yaml.load()` can execute arbitrary code from a file, which is generally not what you want when opening a document. `safe_load()` is ~always what you want when reading YAML.

See the warning [in the PyYAML docs](http://pyyaml.org/wiki/PyYAMLDocumentation#LoadingYAML). Even if all of the examples following the warning use the unsafe functions anyway :angry: .